### PR TITLE
Rename master branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,19 @@
 A small collection of user friendly git commands.
 
 - `git last-tag` displays the latest tag.
-- `git next-tag` increments SemVer style tags. Args `major|minor|patch(default)`
-- `git purge-merged` clean up task deleting all branches merged into master.
+- `git next-tag` increments SemVer style tags. Args `major|minor|patch(default)`.
+- `git purge` clean up task deleting all branches merged into master.
+- `git info` display branches colour coded by merged status.
+- `git main` checks for master or main branch, exits with error if none or both are found.
+- `git migrate-branch` built to support the switch to `main` branch. A move from the technology industry to abolish slavery references. Also supports migrating arbitary branches from one name space to another. `git migrate` assumes `git mirgrate master main`. Steps involeda are. 
+  1. Check your current branch status
+  2. Checkout deprecated branch
+  3. Branch to new namespace
+  4. Push to origin
+  5. Delete deprecated branch locally
+  6. Finally delete from remote.
+- `git prettylog` oneline summary log output.
+- `git mv-branch` script to move/migrate branch names locally & on remote. By default it migrates master branch to main for a more inclusive tech industry.
 
 ### Why Git Commands
 

--- a/bin/git-info
+++ b/bin/git-info
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# shellcheck disable=SC2207
-# Supporting bash 3 output to array =()
+set -e
 
 # TODO: investigate if merged at date is possible to include
 # TODO: investigate if created at date is possible to include
@@ -10,26 +9,43 @@
 COLOR_UNMERGED='\033[1;31m' # Light Red
 COLOR_MERGED='\033[1;32m' # Light Green
 COLOR_CURRENT='\033[1;33m' # Yellow
+COLOR_MAIN='\033[1;34m' # Blue
 COLOR_NONE='\033[0m'
 
 function colorPrint {
   printf "${2} %s ${COLOR_NONE}" "$1"
 }
 
-BRANCHES=($(git branch | tr '*' ' '))
-MERGED=($(git branch --merged master | tr '*' ' '))
+MASTER_BRANCH=$(git main)
+echo $MASTER_BRANCH
+# shellcheck disable=SC2207
+BRANCHES=($(git branch --format='%(refname:short)'))
+# MERGED=($(git branch --merged "$(git main)" | tr '*' ' '))
+# shellcheck disable=SC2207
+MERGED=($(git branch --merged $MASTER_BRANCH --format='%(refname:short)'))
+# shellcheck disable=SC2207
 UNMERGED=($(git branch --no-merged))
 CURRENT_BRANCH=$(git branch --show-current)
 
 # Ledgend
 colorPrint "merged" "$COLOR_MERGED"
 colorPrint "unmerged" "$COLOR_UNMERGED"
-colorPrint "cuurent" "$COLOR_CURRENT"
+colorPrint "current" "$COLOR_CURRENT"
+colorPrint "main" "$COLOR_MAIN"
+echo "" &&
+echo "" &&
+:
 
 for BRANCH in "${BRANCHES[@]}"
 do
-  if [[ " ${CURRENT_BRANCH[*]} " == *" $BRANCH "* ]]; then
+  if [[ " $CURRENT_BRANCH " == *" $BRANCH "* ]]; then
     colorPrint "$BRANCH" "$COLOR_CURRENT"
+    echo "" &&
+    :
+    continue
+  fi
+  if [[ " $MASTER_BRANCH " == *" $BRANCH "* ]]; then
+    colorPrint "$BRANCH" "$COLOR_MAIN"
     echo "" &&
     :
     continue

--- a/bin/git-info
+++ b/bin/git-info
@@ -17,12 +17,12 @@ function colorPrint {
 }
 
 MASTER_BRANCH=$(git main)
-echo $MASTER_BRANCH
+
 # shellcheck disable=SC2207
 BRANCHES=($(git branch --format='%(refname:short)'))
 # MERGED=($(git branch --merged "$(git main)" | tr '*' ' '))
 # shellcheck disable=SC2207
-MERGED=($(git branch --merged $MASTER_BRANCH --format='%(refname:short)'))
+MERGED=($(git branch --merged "$MASTER_BRANCH" --format='%(refname:short)'))
 # shellcheck disable=SC2207
 UNMERGED=($(git branch --no-merged))
 CURRENT_BRANCH=$(git branch --show-current)

--- a/bin/git-main
+++ b/bin/git-main
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+COLOR_WARNING=$(printf '\033[1;31m') # Light Red
+COLOR_NONE=$(printf '\033[0m')
+
+MASTER_BRANCH="master"
+MAIN_BRANCH="main"
+
+# shellcheck disable=SC2207
+BRANCHES=($(git branch | tr '*' ' '))
+
+if [[ " ${BRANCHES[*]} " == *" $MASTER_BRANCH "* && " ${BRANCHES[*]} " == *" $MAIN_BRANCH "* ]]; then
+  cat << EOF
+  ${COLOR_WARNING}
+  Error: This repo has a main and master branch!!!
+  ${COLOR_NONE}
+  The main branch is indistinguishable.
+  Favor main over master.
+
+EOF
+  exit 1
+fi
+
+if [[ " ${BRANCHES[*]} " != *" $MASTER_BRANCH "* && " ${BRANCHES[*]} " != *" $MAIN_BRANCH "* ]]; then
+  cat << EOF
+  ${COLOR_WARNING}
+  Error: This repo no main or master branch!!!
+  ${COLOR_NONE}
+  The main branch is indistinguishable.
+  Favor main over master. 
+
+EOF
+  exit 1
+fi
+
+if [[ " ${BRANCHES[*]} " == *" $MASTER_BRANCH "* ]]; then
+  echo "${MASTER_BRANCH}"
+  exit 0
+fi
+
+if [[ " ${BRANCHES[*]} " == *" $MAIN_BRANCH "* ]]; then
+  echo "${MAIN_BRANCH}"
+  exit 0
+fi

--- a/bin/git-main
+++ b/bin/git-main
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-COLOR_WARNING=$(printf '\033[1;31m') # Light Red
-COLOR_NONE=$(printf '\033[0m')
+set -e
+
+COLOR_WARNING=$(tput setaf 1) # Light Red
+COLOR_NONE=$(tput setaf 0)
 
 MASTER_BRANCH="master"
 MAIN_BRANCH="main"

--- a/bin/git-mv-branch
+++ b/bin/git-mv-branch
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+FROM_BRANCH=${1:-master}
+TO_BRANCH=${2:-main}
+REMOTE="origin"
+
+git ls-remote --exit-code origin > /dev/null 2>&1
+HAS_ORIGIN=$?
+
+# Check for 0 or 2 arguments
+if [[ $# != 0 && $# != 2 ]]; then
+  echo "Error: Invalid number of arguments. git migrate-branch from to (defaults master -> main)"
+  exit 1
+fi
+
+# Check your current branch status
+if [[ $(git status -uno -s | wc -c) -ne 0 ]]; then
+  echo "Error: Branch is dirty, commit or stash your changes first!"
+  exit 1
+fi
+echo "Branch is clean" &&
+
+# Checkout deprecated branch
+git checkout $FROM_BRANCH
+echo "Checked out $FROM_BRANCH" &&
+
+# Branch to new namespace
+git checkout -b $TO_BRANCH
+echo "Created branch $TO_BRANCH" &&
+
+# Push to origin if it exists
+if [[ $HAS_ORIGIN -eq 0  ]]; then
+  git push -u $REMOTE $TO_BRANCH
+  echo "Pushing new branch $TO_BRANCH to $REMOTE" &&
+  :
+fi
+
+
+echo "It is reccommended to delete previous branch locally and on remote" &&
+echo "Delete old branches locally and on remote? [y/N]"
+read -r RESPONSE
+
+# Clean up local branch
+if [[ $RESPONSE =~ ^[Yy]$ ]]; then
+  git branch -D $FROM_BRANCH
+  echo "Deleted branch $FROM_BRANCH from local" &&
+  :
+fi
+
+# Clean up local remote
+if [[ $RESPONSE =~ ^[Yy]$ && $HAS_ORIGIN -eq 0 ]]; then
+  git push $REMOTE --delete $FROM_BRANCH
+  echo "Deleted branch $FROM_BRANCH from $REMOTE" &&
+  :
+fi
+
+echo "Done: successfully migrated from $FROM_BRANCH to $TO_BRANCH"

--- a/bin/git-mv-branch
+++ b/bin/git-mv-branch
@@ -7,6 +7,8 @@ REMOTE="origin"
 git ls-remote --exit-code origin > /dev/null 2>&1
 HAS_ORIGIN=$?
 
+set -e
+
 # Check for 0 or 2 arguments
 if [[ $# != 0 && $# != 2 ]]; then
   echo "Error: Invalid number of arguments. git migrate-branch from to (defaults master -> main)"
@@ -21,16 +23,16 @@ fi
 echo "Branch is clean" &&
 
 # Checkout deprecated branch
-git checkout $FROM_BRANCH
+git checkout "$FROM_BRANCH"
 echo "Checked out $FROM_BRANCH" &&
 
 # Branch to new namespace
-git checkout -b $TO_BRANCH
+git checkout -b "$TO_BRANCH"
 echo "Created branch $TO_BRANCH" &&
 
 # Push to origin if it exists
 if [[ $HAS_ORIGIN -eq 0  ]]; then
-  git push -u $REMOTE $TO_BRANCH
+  git push -u "$REMOTE" "$TO_BRANCH"
   echo "Pushing new branch $TO_BRANCH to $REMOTE" &&
   :
 fi
@@ -42,14 +44,14 @@ read -r RESPONSE
 
 # Clean up local branch
 if [[ $RESPONSE =~ ^[Yy]$ ]]; then
-  git branch -D $FROM_BRANCH
+  git branch -D "$FROM_BRANCH"
   echo "Deleted branch $FROM_BRANCH from local" &&
   :
 fi
 
 # Clean up local remote
 if [[ $RESPONSE =~ ^[Yy]$ && $HAS_ORIGIN -eq 0 ]]; then
-  git push $REMOTE --delete $FROM_BRANCH
+  git push $REMOTE --delete "$FROM_BRANCH"
   echo "Deleted branch $FROM_BRANCH from $REMOTE" &&
   :
 fi

--- a/bin/git-purge
+++ b/bin/git-purge
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # TODO: Purge origin `git purge origin`
 # TODO: Include force flag to bypass warning `git purge -f`
@@ -14,8 +14,8 @@ echo "" && :
 
 echo "Are you sure? [y/N] "
 
-read -r response
+read -r RESPONSE
 
-if echo "$response" | grep -Eq "^([yY][eE][sS]|[yY])$"; then
+if [[ $RESPONSE =~ ^[Yy]$ ]]; then
     git branch --merged| grep -v -E  "(^\*|master)" | xargs git branch -d
 fi


### PR DESCRIPTION
Migration script to move branches `master` to a more inclusive `main` branch.
Will optionall clean up previous branch names locally and on remote.